### PR TITLE
improved clamp:auto

### DIFF
--- a/src/clamp.js
+++ b/src/clamp.js
@@ -89,7 +89,7 @@
      * on the current height of the element and the line-height of the text.
      */
     function getMaxLines(height) {
-      var availHeight = height || element.clientHeight,
+      var availHeight = height || (element.parentNode.clientHeight-element.offsetTop),
         lineHeight = getLineHeight(element);
 
       return Math.max(Math.floor(availHeight / lineHeight), 0);


### PR DESCRIPTION
fix: When the vertical ellipse is placed in an element with a parent with many childs the 'auto' clamp dont works. Its unable to calculate the correct height.
