### PR TITLE
Allow passing 'useNativeClamp' to clamp.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,11 +57,13 @@ Dotdotdot.propTypes = {
     PropTypes.bool
   ]).isRequired,
   truncationChar: PropTypes.string,
+  useNativeClamp: PropTypes.bool,
   className: PropTypes.string
 };
 
 Dotdotdot.defaultProps = {
-  truncationChar: '\u2026'
+  truncationChar: '\u2026',
+  useNativeClamp: true
 };
 
 module.exports = Dotdotdot;

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ Dotdotdot.prototype.dotdotdot = function(container) {
 
     clamp(container, {
       clamp: this.props.clamp,
+      useNativeClamp: this.props.useNativeClamp,
       truncationChar: this.props.truncationChar
     });
   }


### PR DESCRIPTION
I'd like to pass useNativeClamp to clamp.js to get consistent behaviour across browsers