### PR TITLE
Fix word breaking for long text

### DIFF
--- a/src/clamp.js
+++ b/src/clamp.js
@@ -273,6 +273,7 @@
       sty.webkitBoxOrient = 'vertical';
       sty.display = '-webkit-box';
       sty.webkitLineClamp = clampValue;
+      sty.wordBreak = 'break-all';
 
       if (isCSSValue) {
         sty.height = opt.clamp + 'px';


### PR DESCRIPTION
This pull request fixes clamping for long words with no spaces.

It addresses https://github.com/CezaryDanielNowak/React-dotdotdot/issues/21 and https://github.com/CezaryDanielNowak/React-dotdotdot/issues/15.