### PR TITLE
round line-height value from computed float value

### DIFF
--- a/src/clamp.js
+++ b/src/clamp.js
@@ -112,9 +112,9 @@
       if (lh == 'normal') {
         // Normal line heights vary from browser to browser. The spec recommends
         // a value between 1.0 and 1.2 of the font size. Using 1.1 to split the diff.
-        lh = parseInt(computeStyle(elem, 'font-size'), 10) * 1.2;
+        lh = parseFloat(computeStyle(elem, 'font-size')) * 1.2;
       }
-      return parseInt(lh, 10);
+      return Math.round(parseFloat(lh));
     }
 
 


### PR DESCRIPTION
In IE11, when the actual line height is 22.88px, it turns out that element's `clientHeight` returns 23, not 22. `getLineHeight` function returns 22 as a result of `parseInt`. This causes the condition in https://github.com/CezaryDanielNowak/React-dotdotdot/blob/98875e7206470dcfb862839d47a01ccdb4617656/src/clamp.js#L230 to fail and the element gets truncated until it's empty.

How to reproduce:
https://jsbin.com/nijapexemu/edit?js,output