### PR TITLE
docs: update new default value of useNativeClamp in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Dotdotdot props:
 ----------------
 **clamp** (Number | String | 'auto'). This controls where and when to clamp the text of an element. Submitting a number controls the number of lines that should be displayed. Second, you can submit a CSS value (in px or em) that controls the height of the element as a String. Finally, you can submit the word 'auto' as a string. Auto will try to fill up the available space with the content and then automatically clamp once content no longer fits. This last option should only be set if a static height is being set on the element elsewhere (such as through CSS) otherwise no clamping will be done.
 
-**useNativeClamp**: [default: `true`] Use -webkit-line-clamp available in Webkit (Chrome, Safari) only.
+**useNativeClamp**: [default: `false`] Use -webkit-line-clamp available in Webkit (Chrome, Safari) only.
 
 **splitOnChars**: [default: `['.', '-', '–', '—', ' ']`] Split on sentences (periods), hypens, en-dashes, em-dashes, and words (spaces).
 


### PR DESCRIPTION
In version 1.3.0 (https://github.com/CezaryDanielNowak/React-dotdotdot/commit/98875e7206470dcfb862839d47a01ccdb4617656) the default value of `useNativeClamp` was changed to `false`, but the respective documentation in the README file was not updated and still says `true` is the default value. This changes the readme to have the correct default value of `false` again.