### PR TITLE
fix: content not re-expanding on container grow

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,10 @@ Dotdotdot.prototype.dotdotdot = function(container) {
     if (container.length) {
       throw new Error('Please provide exacly one child to dotdotdot');
     }
+
+    if (!this._originalContent) this._originalContent = container.innerHTML
+    container.innerHTML = this._originalContent
+
     clamp(container, pick(this.props, [
       'animate',
       'clamp',


### PR DESCRIPTION
This PR fixes an issue where the content will reclamp on container shrink (window resize), but it will not re-expand on container grow. This is because the content is imperatively being eliminated from the container on shrink and not being stored anywhere.