### PR TITLE
getComputedStyle(...) is null fixed

### DIFF
--- a/src/clamp.js
+++ b/src/clamp.js
@@ -81,7 +81,8 @@
         };
       }
 
-      return win.getComputedStyle(elem, null).getPropertyValue(prop);
+      const computedStyle = win.getComputedStyle(elem, null);
+      return computedStyle ? computedStyle.getPropertyValue(prop) : null;
     }
 
     /**


### PR DESCRIPTION
window.getComputedStyle() may return null in Firefox : https://github.com/marcj/css-element-queries/issues/148